### PR TITLE
Moved menu separator to separate scenes and app actions

### DIFF
--- a/Scenecuts/StatusBarController.swift
+++ b/Scenecuts/StatusBarController.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Cocoa
 import SwiftUI
+import SFSafeSymbols
 import KeyboardShortcuts
 
 class StatusBarController {
@@ -17,20 +18,21 @@ class StatusBarController {
     private lazy var mainStatusItem: NSStatusItem = {
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         
-        statusItem.button?.image = NSImage(systemSymbolName: "homekit", accessibilityDescription: nil)?.withSymbolConfiguration(.init(pointSize: 14, weight: .regular))
+        statusItem.button?.image = NSImage(systemSymbolName: SFSymbol.homekit.rawValue, accessibilityDescription: nil)?.withSymbolConfiguration(.init(pointSize: 14, weight: .regular))
         statusItem.button?.target = self
         
         let menu = NSMenu()
-        let menuItem = menu.addItem(withTitle: "\(Localized.preferences.localizedCapitalized)...", action: #selector(openPreferences), keyEquivalent: ",")
-        menuItem.target = self
-        statusItem.menu = menu
         
         // MARK: Add separator
         menu.addItem(NSMenuItem.separator())
-        
+
+        let menuItem = menu.addItem(withTitle: "\(Localized.preferences.localizedCapitalized)…", action: #selector(openPreferences), keyEquivalent: ",")
+        menuItem.target = self
+                
         let quitMenuItem = menu.addItem(withTitle: "\(Localized.quit.localizedCapitalized)", action: #selector(quit), keyEquivalent: "q")
         quitMenuItem.target = self
         
+        statusItem.menu = menu
         return statusItem
     }()
     


### PR DESCRIPTION
Similar to #13, but adds other changes:

- Moved menu separator to be between the HomeKit scenes and the app actions (Preferences, Quit).
- Changed “Preferences…” string to use an ellipsis character instead of 3 dots as specified on the [Mac Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-anatomy/).
- Migrated HomeKit symbol reference to `SFSafeSymbols`.

<img width="696" alt="Captura de pantalla 2020-12-06 a las 19 28 15" src="https://user-images.githubusercontent.com/1706695/101288880-3590d280-37f9-11eb-8c99-a603e0eaeb91.png">